### PR TITLE
fix: persist customer orders before confirmation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,10 @@
 App({
+  onLaunch() {
+    if (wx.cloud) {
+      wx.cloud.init({ traceUser: true })
+    }
+  },
+
   globalData: {
     userInfo: null,
     currentRole: 'customer'

--- a/pages/customer/index.js
+++ b/pages/customer/index.js
@@ -8,7 +8,8 @@ Page({
     proxyAmount: '',
     deliveryFee: DEFAULT_DELIVERY_FEE,
     address: '',
-    pricing: calculateOrderTotal(0, DEFAULT_DELIVERY_FEE)
+    pricing: calculateOrderTotal(0, DEFAULT_DELIVERY_FEE),
+    submitting: false
   },
 
   onStoreNameInput(event) {
@@ -37,25 +38,56 @@ Page({
     this.setData({ pricing: calculateOrderTotal(proxyAmount, deliveryFee) })
   },
 
-  submitOrder() {
+  async submitOrder() {
+    if (this.data.submitting) {
+      return
+    }
+
     if (!this.data.storeName || !this.data.itemsText || !Number(this.data.proxyAmount) || !this.data.address) {
       wx.showToast({ title: '请补全订单信息', icon: 'none' })
       return
     }
 
+    if (!wx.cloud) {
+      wx.showToast({ title: '云开发未初始化，无法创建订单', icon: 'none' })
+      return
+    }
+
+    const db = wx.cloud.database()
     const order = {
       storeName: this.data.storeName,
       itemsText: this.data.itemsText,
       address: this.data.address,
       pricing: this.data.pricing,
       status: 'pending',
-      createdAt: Date.now()
+      createdAt: db.serverDate()
     }
 
-    wx.showModal({
-      title: '订单已创建',
-      content: `预计支付 ¥${order.pricing.total}，等待附近代购接单。`,
-      showCancel: false
-    })
+    this.setData({ submitting: true })
+
+    try {
+      const result = await db.collection('orders').add({ data: order })
+
+      wx.showModal({
+        title: '订单已创建',
+        content: `预计支付 ¥${order.pricing.total}，等待附近代购接单。`,
+        showCancel: false
+      })
+
+      this.setData({
+        storeName: '',
+        itemsText: '',
+        proxyAmount: '',
+        deliveryFee: DEFAULT_DELIVERY_FEE,
+        address: '',
+        pricing: calculateOrderTotal(0, DEFAULT_DELIVERY_FEE),
+        lastOrderId: result._id
+      })
+    } catch (error) {
+      wx.showToast({ title: '订单创建失败，请稍后重试', icon: 'none' })
+      console.error('create order failed', error)
+    } finally {
+      this.setData({ submitting: false })
+    }
   }
 })

--- a/pages/customer/index.wxml
+++ b/pages/customer/index.wxml
@@ -40,5 +40,5 @@
     </view>
   </view>
 
-  <button class="primary-button" bindtap="submitOrder">提交订单</button>
+  <button class="primary-button" loading="{{submitting}}" disabled="{{submitting}}" bindtap="submitOrder">提交订单</button>
 </view>


### PR DESCRIPTION
### Motivation

- Fix a high-priority bug where customer-created orders were only built in-memory and never saved to the `orders` collection, causing them to vanish and preventing shoppers from seeing pending orders. 
- Ensure the app can use cloud database APIs from the customer page and avoid duplicate submissions or false success confirmations.

### Description

- Initialize WeChat Cloud in `app.js` by adding an `onLaunch` that calls `wx.cloud.init({ traceUser: true })` so cloud APIs are available at runtime. 
- Convert `pages/customer/index.js` `submitOrder` to `async` and add a `submitting` flag to prevent duplicate submissions. 
- Persist orders by calling `db.collection('orders').add({ data: order })` (using `db.serverDate()` for `createdAt`), show the success modal only after a successful write, and save the returned `result._id` in `lastOrderId`. 
- Add error handling to surface failures with `wx.showToast` and reset the form fields only after a successful save, plus bind the submit button loading/disabled state in `pages/customer/index.wxml` to `submitting`.

### Testing

- Performed syntax checks with `node --check` for `app.js`, `cloudfunctions/matchOrders/index.js`, `pages/customer/index.js`, `pages/shopper/index.js`, and `pages/mine/index.js`, which passed. 
- Ran unit checks `node tests/fee.test.js` and `node tests/distance.test.js`, both of which passed and reported success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09ca3c57308332889092d038780951)